### PR TITLE
Fixed VarInt and VarLong max size

### DIFF
--- a/net/packet/types.go
+++ b/net/packet/types.go
@@ -277,10 +277,10 @@ func (v *VarInt) Decode(r DecodeReader) error {
 
 		n |= uint32(sec&0x7F) << uint32(7*i)
 
-		if sec&0x80 == 0 {
-			break
-		} else if i > 5 {
+		if i >= 5 {
 			return errors.New("VarInt is too big")
+		} else if sec&0x80 == 0 {
+			break
 		}
 	}
 
@@ -316,10 +316,10 @@ func (v *VarLong) Decode(r DecodeReader) error {
 
 		n |= uint64(sec&0x7F) << uint64(7*i)
 
-		if sec&0x80 == 0 {
+		if i >= 10 {
+			return errors.New("VarLong is too big")
+		} else if sec&0x80 == 0 {
 			break
-		} else if i > 10 {
-			return errors.New("VarInt is too big")
 		}
 	}
 


### PR DESCRIPTION
Before VarInt could have had a size of 7 byte without generating errors (max should be 5).
>= 5 is because we start from 0 and i=5 is already in error.
For example if byte of VarInt are [255 255 255 255 255 255 1], at penultimate iteration, i will be 5 (start at 0) so there aren't errors and at the last the break bypass the sec&0x80 check.
Same for VarLong.