### PR TITLE
指定當傳送加入伺服器的請求至Mojang時的Content-Type標頭

### DIFF
--- a/bot/login.go
+++ b/bot/login.go
@@ -185,6 +185,7 @@ func loginAuth(AsTk, name, UUID string, shareSecret []byte, er encryptionRequest
 	}
 	PostRequest.Header.Set("User-agent", "go-mc")
 	PostRequest.Header.Set("Connection", "keep-alive")
+	PostRequest.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(PostRequest)
 	if err != nil {
 		return fmt.Errorf("post fail: %v", err)


### PR DESCRIPTION
官方好像正常是要指定Content-Type( https://wiki.vg/Authentication#Request_format )
現在是不加沒關係
但如果Mojang修正的話可能會出錯