### PR TITLE
Support for Minecraft 1.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go-MC
-![Version](https://img.shields.io/badge/Minecraft-1.16.1-blue.svg)
-![Protocol](https://img.shields.io/badge/Protocol-736-blue.svg)
+![Version](https://img.shields.io/badge/Minecraft-1.16.2-blue.svg)
+![Protocol](https://img.shields.io/badge/Protocol-751-blue.svg)
 [![GoDoc](https://godoc.org/github.com/Tnze/go-mc?status.svg)](https://godoc.org/github.com/Tnze/go-mc)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Tnze/go-mc)](https://goreportcard.com/report/github.com/Tnze/go-mc)
 [![Build Status](https://travis-ci.org/Tnze/go-mc.svg?branch=master)](https://travis-ci.org/Tnze/go-mc)

--- a/bot/ingame.go
+++ b/bot/ingame.go
@@ -486,9 +486,6 @@ func handleChunkDataPacket(c *Client, p pk.Packet) error {
 	return err
 }
 
-//
-//  None of this works and I'm all out of ideas
-//
 type biomesData struct {
 	fullChunk *bool
 	data      []pk.VarInt
@@ -499,13 +496,19 @@ func (b *biomesData) Decode(r pk.DecodeReader) error {
 		return nil
 	}
 
-	var nobe pk.VarInt // Number of BlockEntities
-	if err := nobe.Decode(r); err != nil {
+	var nobd pk.VarInt // Number of Biome Datums
+	if err := nobd.Decode(r); err != nil {
 		return err
 	}
-	b.data = make([]pk.VarInt, nobe)
-	if _, err := r.Read(b.data); err != nil {
-		return err
+
+	b.data = make([]pk.VarInt, nobd)
+
+	for i := 0; i < int(nobd); i++ {
+		var d pk.VarInt
+		if err := d.Decode(r); err != nil {
+			return err
+		}
+		b.data[i] = d
 	}
 
 	return nil

--- a/bot/ingame.go
+++ b/bot/ingame.go
@@ -192,7 +192,6 @@ func handleDisconnectPacket(c *Client, p pk.Packet) error {
 	}
 
 	if c.Events.Disconnect != nil {
-		fmt.Println("c.Events.Disconnect=%+v\n", c.Events.Disconnect)
 		return c.Events.Disconnect(reason)
 	}
 	return nil

--- a/bot/ingame.go
+++ b/bot/ingame.go
@@ -466,14 +466,6 @@ func handleChunkDataPacket(c *Client, p pk.Packet) error {
 		BlockEntities  blockEntities
 	)
 	if err := p.Scan(&X, &Z, &FullChunk, &PrimaryBitMask, pk.NBT{V: &Heightmaps}, &Biomes, &Data, &BlockEntities); err != nil {
-		fmt.Println("-- ")
-		fmt.Printf("X=%v Z=%v\n", X, Z)
-		fmt.Printf("Fullchunk %v\n", FullChunk)
-		fmt.Printf("BitMask=%v\n", PrimaryBitMask)
-		fmt.Printf("Heightmaps: %v\n", Heightmaps)
-		fmt.Printf("Biomes: %+v\n", Biomes)
-		fmt.Printf("Data: %+v\n", Data)
-		fmt.Println("-- ")
 		return err
 	}
 	chunk, err := world.DecodeChunkColumn(int32(PrimaryBitMask), Data)

--- a/bot/mcbot.go
+++ b/bot/mcbot.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ProtocolVersion , the protocol version number of minecraft net protocol
-const ProtocolVersion = 736
+const ProtocolVersion = 751
 
 // JoinServer connect a Minecraft server for playing the game.
 func (c *Client) JoinServer(addr string, port int) (err error) {

--- a/data/packetIDs.go
+++ b/data/packetIDs.go
@@ -134,10 +134,11 @@ const (
 	PlayerDigging
 	EntityAction
 	SteerVehicle
+	DisplayedRecipe
 	RecipeBookData
-	NameItem
 
-	ResourcePackStatus //0x20
+	NameItem //0x20
+	ResourcePackStatus
 	AdvancementTab
 	SelectTrade
 	SetBeaconEffect
@@ -151,5 +152,5 @@ const (
 	AnimationServerbound
 	Spectate
 	PlayerBlockPlacement
-	UseItem //0x2E
+	UseItem //0x2F
 )

--- a/data/packetIDs.go
+++ b/data/packetIDs.go
@@ -17,10 +17,9 @@ const (
 	BossBar
 	ServerDifficulty
 	ChatMessageClientbound
-	MultiBlockChange
+	TabComplete
 
-	TabComplete //0x10
-	DeclareCommands
+	DeclareCommands //0x10
 	WindowConfirmationClientbound
 	CloseWindowClientbound
 	WindowItems
@@ -35,9 +34,9 @@ const (
 	UnloadChunk
 	ChangeGameState
 	OpenHorseWindow
+	KeepAliveClientbound
 
-	KeepAliveClientbound //0x20
-	ChunkData
+	ChunkData //0x20
 	Effect
 	Particle
 	UpdateLight
@@ -52,9 +51,9 @@ const (
 	OpenBook
 	OpenWindow
 	OpenSignEditor
+	CraftRecipeResponse
 
-	CraftRecipeResponse //0x30
-	PlayerAbilitiesClientbound
+	PlayerAbilitiesClientbound //0x30
 	CombatEvent
 	PlayerInfo
 	FacePlayer
@@ -65,6 +64,7 @@ const (
 	ResourcePackSend
 	Respawn
 	EntityHeadLook
+	MultiBlockChange
 	SelectAdvancementTab
 	WorldBorder
 	Camera


### PR DESCRIPTION
This is my attempt to update to the 1.16.2 protocol version 751.  I've got all the packetID mappings fixed and updated a few of the packet decoding functions as well.

The biggest change is a new structure for biomesData as part of the `handleChunkDataPacket` function.  The biomesData has changed from being a fixed `[1024]int32` array to a variable-sized array (similar to how BlockEntities are handled).

I've got it working now, and everything seems to be ok with my bots.