### PR TITLE
Add marshaling of struct and interface types for nbt

### DIFF
--- a/nbt/marshal_test.go
+++ b/nbt/marshal_test.go
@@ -55,3 +55,87 @@ func TestMarshal_FloatArray(t *testing.T) {
 		t.Errorf("output binary not right: get % 02x, want % 02x ", buf.Bytes(), out)
 	}
 }
+
+func TestMarshal_InterfaceArray(t *testing.T) {
+	type Struct1 struct {
+		Val int32
+	}
+
+	type Struct2 struct {
+		Val float32
+	}
+
+	tests := []struct {
+		name string
+		args []interface{}
+		want []byte
+	}{
+		{
+			name: "Two element interface array",
+			args: []interface{}{Struct1{3}, Struct2{0.3}},
+			want: []byte{
+				TagList, 0x00, 0x00 /*no name*/, TagCompound, 0, 0, 0, 2,
+				// 1st element
+				TagCompound, 0x00, 0x00, /*no name*/
+				TagInt, 0x00, 0x03, 'V', 'a', 'l', 0x00, 0x00, 0x00, 0x03, // 3
+				TagEnd,
+				// 2nd element
+				TagCompound, 0x00, 0x00, /*no name*/
+				TagFloat, 0x00, 0x03, 'V', 'a', 'l', 0x3e, 0x99, 0x99, 0x9a, // 0.3
+				TagEnd,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			err := Marshal(w, tt.args)
+			if err != nil {
+				t.Error(err)
+			} else if !bytes.Equal(w.Bytes(), tt.want) {
+				t.Errorf("Marshal([]interface{}) got = % 02x, want % 02x", w.Bytes(), tt.want)
+				return
+			}
+		})
+	}
+}
+
+func TestMarshal_StructArray(t *testing.T) {
+	type Struct1 struct {
+		Val int32
+	}
+
+	tests := []struct {
+		name string
+		args []Struct1
+		want []byte
+	}{
+		{
+			name: "One element struct array",
+			args: []Struct1{{3}, {-10}},
+			want: []byte{
+				TagList, 0x00, 0x00 /*no name*/, TagCompound, 0, 0, 0, 2,
+				// 1st element
+				TagCompound, 0x00, 0x00, /*no name*/
+				TagInt, 0x00, 0x03, 'V', 'a', 'l', 0x00, 0x00, 0x00, 0x03, // 3
+				TagEnd,
+				// 2nd element
+				TagCompound, 0x00, 0x00, /*no name*/
+				TagInt, 0x00, 0x03, 'V', 'a', 'l', 0xff, 0xff, 0xff, 0xf6, // -10
+				TagEnd,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &bytes.Buffer{}
+			err := Marshal(w, tt.args)
+			if err != nil {
+				t.Error(err)
+			} else if !bytes.Equal(w.Bytes(), tt.want) {
+				t.Errorf("Marshal([]struct{}) got = % 02x, want % 02x", w.Bytes(), tt.want)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Move list header creation to a common helper function
- Add switch statement for slices/arrays of structs & interfaces to `marshal` that recursively calls `marshal` on the underlying type
- Add tests for interface and struct slices