### PR TITLE
Changed packet array error message to clarify the addressable error

### DIFF
--- a/net/packet/util.go
+++ b/net/packet/util.go
@@ -62,7 +62,7 @@ func (a Ary) ReadFrom(r io.Reader) (n int64, err error) {
 		array = array.Elem()
 	}
 	if !array.CanAddr() {
-		panic(errors.New("the contents of the array are not addressable"))
+		panic(errors.New("the contents of the Ary are not addressable"))
 	}
 	if array.Cap() < length {
 		array.Set(reflect.MakeSlice(array.Type(), length, length))

--- a/net/packet/util.go
+++ b/net/packet/util.go
@@ -62,7 +62,7 @@ func (a Ary) ReadFrom(r io.Reader) (n int64, err error) {
 		array = array.Elem()
 	}
 	if !array.CanAddr() {
-		panic(errors.New("the Ary is not addressable"))
+		panic(errors.New("the contents of the array are not addressable"))
 	}
 	if array.Cap() < length {
 		array.Set(reflect.MakeSlice(array.Type(), length, length))


### PR DESCRIPTION
When working with the packet Ary type, setting the Ary's contents to something that is not addressable, returns an error message that implies that the Ary itself is not addressable, instead of its contents

This PR includes a small error message change that clarifies this