### PR TITLE
Fix empty text in components

### DIFF
--- a/chat/message.go
+++ b/chat/message.go
@@ -41,7 +41,9 @@ const (
 	White       = "white"
 )
 
-// Message represents all fields that every chat component has
+// Message represents a Minecraft chat component which format is described at https://wiki.vg/Chat. You can
+// use chat.Text and chat.TranslateMsg to get an instance of Message. Message can be a string component or a
+// translation, use IsText and IsTranslation methods to determine a type of your message instance.
 type Message struct {
 	*MessageText
 	*MessageTranslation

--- a/chat/message.go
+++ b/chat/message.go
@@ -43,7 +43,7 @@ const (
 
 // Message is a message sent by other
 type Message struct {
-	Text string `json:"text,omitempty"`
+	Text string `json:"text"`
 
 	Bold          bool `json:"bold,omitempty"`          //粗体
 	Italic        bool `json:"italic,omitempty"`        //斜体

--- a/examples/frameworkServer/main.go
+++ b/examples/frameworkServer/main.go
@@ -19,7 +19,11 @@ import (
 	"github.com/Tnze/go-mc/server/command"
 )
 
-var motd = chat.Message{Text: "A Minecraft Server ", Extra: []chat.Message{{Text: "Powered by go-mc", Color: "yellow"}}}
+var motd = chat.Message{
+	MessageText: &chat.MessageText{Text: "A Minecraft Server "},
+	Extra:       []chat.Message{{MessageText: &chat.MessageText{Text: "Powered by go-mc"}, Color: "yellow"}},
+}
+
 var addr = flag.String("Address", ":25565", "Listening address")
 var iconPath = flag.String("ServerIcon", "./server-icon.png", "The path to server icon")
 var maxPlayer = flag.Int("MaxPlayer", 16384, "The maximum number of players")

--- a/examples/simpleServer1.15.2/status.go
+++ b/examples/simpleServer1.15.2/status.go
@@ -57,7 +57,7 @@ func listResp() string {
 	list.Players.Max = MaxPlayer
 	list.Players.Online = 123
 	list.Players.Sample = []player{} // must init. can't be nil
-	list.Description = chat.Message{Text: "Powered by go-mc", Color: "blue"}
+	list.Description = chat.Message{MessageText: &chat.MessageText{Text: "Powered by go-mc"}, Color: "blue"}
 
 	data, err := json.Marshal(list)
 	if err != nil {

--- a/examples/simpleServer1.17.1/status.go
+++ b/examples/simpleServer1.17.1/status.go
@@ -55,7 +55,7 @@ func listResp() string {
 	list.Players.Max = MaxPlayer
 	list.Players.Online = 123
 	list.Players.Sample = []player{} // must init. can't be nil
-	list.Description = chat.Message{Text: "Powered by go-mc", Color: "blue"}
+	list.Description = chat.Message{MessageText: &chat.MessageText{Text: "Powered by go-mc"}, Color: "blue"}
 
 	data, err := json.Marshal(list)
 	if err != nil {

--- a/server/chat.go
+++ b/server/chat.go
@@ -99,9 +99,9 @@ func (c chatItem) toMessage() chat.Message {
 	return chat.TranslateMsg(
 		"chat.type.text",
 		chat.Message{
-			Text:       c.p.Name,
-			ClickEvent: chat.SuggestCommand("/msg " + c.p.Name),
-			HoverEvent: chat.ShowEntity(playerToSNBT(c.p)),
+			MessageText: &chat.MessageText{Text: c.p.Name},
+			ClickEvent:  chat.SuggestCommand("/msg " + c.p.Name),
+			HoverEvent:  chat.ShowEntity(playerToSNBT(c.p)),
 		},
 		chat.Text(c.text),
 	)


### PR DESCRIPTION
Quite a simple fix for some cases when we have JSON component that consists only of `extra` components, but does not have text itself. In such cases Notchian client expects `text` field to have `""` value, but when `Message` is serialized, this field is being omitted, which causes client to throw an exception.