### PR TITLE
Don't send empty host string in handshake

### DIFF
--- a/bot/mcbot.go
+++ b/bot/mcbot.go
@@ -38,6 +38,7 @@ func (c *Client) join(ctx context.Context, d *mcnet.Dialer, addr string) error {
 	host, portStr, err := net.SplitHostPort(addr)
 	var port uint64
 	if err != nil {
+		host = addr
 		var addrErr *net.AddrError
 		const missingPort = "missing port in address"
 		if errors.As(err, &addrErr) && addrErr.Err == missingPort {
@@ -50,9 +51,6 @@ func (c *Client) join(ctx context.Context, d *mcnet.Dialer, addr string) error {
 		if err != nil {
 			return LoginErr{"parse port", err}
 		}
-	}
-	if host == "" {
-		host = addr
 	}
 
 	// Dial connection

--- a/bot/mcbot.go
+++ b/bot/mcbot.go
@@ -38,10 +38,10 @@ func (c *Client) join(ctx context.Context, d *mcnet.Dialer, addr string) error {
 	host, portStr, err := net.SplitHostPort(addr)
 	var port uint64
 	if err != nil {
-		host = addr
 		var addrErr *net.AddrError
 		const missingPort = "missing port in address"
 		if errors.As(err, &addrErr) && addrErr.Err == missingPort {
+			host = addr
 			port = 25565
 		} else {
 			return LoginErr{"split address", err}

--- a/bot/mcbot.go
+++ b/bot/mcbot.go
@@ -51,6 +51,9 @@ func (c *Client) join(ctx context.Context, d *mcnet.Dialer, addr string) error {
 			return LoginErr{"parse port", err}
 		}
 	}
+	if host == "" {
+		host = addr
+	}
 
 	// Dial connection
 	c.Conn, err = d.DialMCContext(ctx, addr)


### PR DESCRIPTION
Host field in handshake packet is used by TCPShield (and probably other services too) to determine on what backend server to route incoming connection to.