### PR TITLE
Use `http.DefaultClient` for requests

### DIFF
--- a/bot/login.go
+++ b/bot/login.go
@@ -126,7 +126,6 @@ type request struct {
 func loginAuth(auth Auth, shareSecret []byte, er encryptionRequest) error {
 	digest := authDigest(er.ServerID, shareSecret, er.PublicKey)
 
-	client := http.Client{}
 	requestPacket, err := json.Marshal(
 		request{
 			AccessToken: auth.AsTk,
@@ -149,7 +148,7 @@ func loginAuth(auth Auth, shareSecret []byte, er encryptionRequest) error {
 	PostRequest.Header.Set("User-agent", "go-mc")
 	PostRequest.Header.Set("Connection", "keep-alive")
 	PostRequest.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(PostRequest)
+	resp, err := http.DefaultClient.Do(PostRequest)
 	if err != nil {
 		return fmt.Errorf("post fail: %v", err)
 	}

--- a/yggdrasil/yggdrasil.go
+++ b/yggdrasil/yggdrasil.go
@@ -26,7 +26,7 @@ func (e Error) Error() string {
 
 var AuthURL = "https://authserver.mojang.com"
 
-var client http.Client
+var client = http.DefaultClient
 
 func post(endpoint string, payload interface{}, resp interface{}) error {
 	rowResp, err := rawPost(endpoint, payload)


### PR DESCRIPTION
Reuse the cached keep alive TCP connections, which may improve performance for the high-frequency request.