### PR TITLE
Fix and improvements to mca

### DIFF
--- a/save/region/mca.go
+++ b/save/region/mca.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"math"
 	"os"
 	"time"
 )
@@ -158,7 +157,7 @@ func (r *Region) ReadSector(x, z int) (data []byte, err error) {
 
 // WriteSector write Chunk data into region file
 func (r *Region) WriteSector(x, z int, data []byte) error {
-	need := int32(math.Ceil(float64(len(data)+4) / 4096))
+	need := int32((len(data) + 4 + 4096 - 1) / 4096)
 	n, now := sectorLoc(r.offsets[z][x])
 
 	// maximum chunk size is 1MB

--- a/save/region/mca.go
+++ b/save/region/mca.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"math"
 	"os"
 	"time"
 )
@@ -152,7 +153,7 @@ func (r *Region) ReadSector(x, z int) (data []byte, err error) {
 
 // WriteSector write Chunk data into region file
 func (r *Region) WriteSector(x, z int, data []byte) error {
-	need := int32(len(data)+4)/4096 + 1
+	need := int32(math.Ceil(float64(len(data)+4) / 4096))
 	n, now := sectorLoc(r.offsets[z][x])
 
 	// maximum chunk size is 1MB


### PR DESCRIPTION
Firstly, this is a fix of the calculation of the required number of sectors. With a data length of 4092, 2 sectors were required instead of 1.

And second, an API improvement for reading .mca files from other sources such as a zip archive.