### PR TITLE
Fixs to the struct so it can properly parse chat messages with hover events etc.

### DIFF
--- a/chat/hoverevent.go
+++ b/chat/hoverevent.go
@@ -2,12 +2,17 @@ package chat
 
 // HoverEvent defines an event that occurs when this component hovered over.
 type HoverEvent struct {
-	Action string  `json:"action"`
-	Value  Message `json:"value"`
+	Action string     `json:"action"`
+	Value  []HoverSub `json:"value"` // The issue i found is the fact the json is different now, it wasnt parsing properly because Message was invalid, its a listed dict.
+}
+
+type HoverSub struct {
+	Color string `json:"color"`
+	Text  string `json:"text"`
 }
 
 // ShowText show the text to display.
-func ShowText(text Message) *HoverEvent {
+func ShowText(text []HoverSub) *HoverEvent {
 	return &HoverEvent{
 		Action: "show_text",
 		Value:  text,
@@ -18,17 +23,29 @@ func ShowText(text Message) *HoverEvent {
 // Item is encoded as the S-NBT format, nbt.StringifiedMessage could help.
 // See: https://wiki.vg/Chat#:~:text=show_item,in%20red%20instead.
 func ShowItem(item string) *HoverEvent {
+	T := Text(item)
 	return &HoverEvent{
 		Action: "show_item",
-		Value:  Text(item),
+		Value: []HoverSub{
+			{
+				Color: T.Color,
+				Text:  T.Text,
+			},
+		},
 	}
 }
 
 // ShowEntity show an entity describing by the S-NBT, nbt.StringifiedMessage could help.
 // See: https://wiki.vg/Chat#:~:text=show_entity,given%20entity%20loaded.
 func ShowEntity(entity string) *HoverEvent {
+	T := Text(entity)
 	return &HoverEvent{
 		Action: "show_entity",
-		Value:  Text(entity),
+		Value: []HoverSub{
+			{
+				Color: T.Color,
+				Text:  T.Color,
+			},
+		},
 	}
 }


### PR DESCRIPTION
the main issue was the value inside the hoverEvent was a listed dict [{}], it couldnt parse because originally you where passing through a string value, i fixed it and yes there is small changes in the hoverEvent.go file, feel free to actually go through it and make changes!! 