### PR TITLE
add KeyManager in server for better client join performance

### DIFF
--- a/server/keypair.go
+++ b/server/keypair.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"sync/atomic"
+
+	"github.com/Tnze/go-mc/net"
+	"github.com/google/uuid"
+)
+
+// KeyManager is the interface to get the RSA key for Encryption Key Request.
+type KeyManager interface {
+	GetServerKey(conn *net.Conn, name string, id uuid.UUID, profilePubKey *rsa.PublicKey) (privKey *rsa.PrivateKey, x509Pub []byte, ok bool)
+}
+
+type KeyPairCache struct {
+	key    *rsa.PrivateKey
+	pubKey []byte
+}
+
+type DefaultKeyManager struct {
+	key atomic.Value // *KeyPairCache
+}
+
+func (km *DefaultKeyManager) GenerateKey(bits int) error {
+	key, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return err
+	}
+	return km.SetKey(key)
+}
+
+func (km *DefaultKeyManager) SetKey(privKey *rsa.PrivateKey) error {
+	publicKey, err := x509.MarshalPKIXPublicKey(&privKey.PublicKey)
+	if err != nil {
+		return err
+	}
+
+	kp := &KeyPairCache{
+		key:    privKey,
+		pubKey: publicKey,
+	}
+	km.key.Store(kp)
+	return nil
+}
+
+func (km *DefaultKeyManager) GetKey() (privKey *rsa.PrivateKey, x509Pub []byte, ok bool) {
+	kp, ok := km.key.Load().(*KeyPairCache)
+	if !ok {
+		return nil, nil, false
+	}
+	return kp.key, kp.pubKey, true
+}
+
+func (km *DefaultKeyManager) GetServerKey(conn *net.Conn, name string, id uuid.UUID, profilePubKey *rsa.PublicKey) (privKey *rsa.PrivateKey, x509Pub []byte, ok bool) {
+	return km.GetKey() // just return
+}
+
+func NewDefaultKeyManager(bits int) (*DefaultKeyManager, error) {
+	km := &DefaultKeyManager{}
+	err := km.GenerateKey(bits)
+	if err != nil {
+		return nil, err
+	}
+	return km, nil
+}


### PR DESCRIPTION
As mentioned in #209 ,
I add `KeyManager` for caching RSA keypair,
not yet add the option for `prevent-proxy-connections: true` right now.


As mentioned in #210  ,

> (By simply store the server's key in the LoginHandler. There is no need to use interface if we have only one implementation.

Add a interface is for user who need more control without re-implement full `MojangLoginHandler`, eg:
1. can automatically generate keypair for N hours (1024 bit RSA is weak)
2. use specific key for specific client if they need

Otherwise we may need to add `GenerateKey()`, `SetKey()`, `GetKey()` on the `MojangLoginHandler` and lost the ability for use specific key for specific client.

BTW. I test vanilla 1.19 client, it can handle up to 8192 bit key without issue. (join will be slower) (more bits are not test)