### PR TITLE
Allow user to provide their own encryption keys

### DIFF
--- a/bot/client.go
+++ b/bot/client.go
@@ -9,8 +9,11 @@ import (
 
 // Client is used to access Minecraft server
 type Client struct {
-	Conn    *net.Conn
-	Auth    Auth
+	Conn *net.Conn
+	Auth Auth
+	// KeyPair Used in login process, can be nil to avoid
+	// sending it to the server. Required to log in to servers
+	// with enforce-secure-profile
 	KeyPair *user.KeyPairResp
 
 	Name string

--- a/bot/mcbot.go
+++ b/bot/mcbot.go
@@ -75,13 +75,9 @@ func (c *Client) join(ctx context.Context, d *mcnet.Dialer, addr string) error {
 		return LoginErr{"handshake", err}
 	}
 	// Login Start
-	KeyPairResp, err := user.GetOrFetchKeyPair(c.Auth.AsTk)
-	if err == nil {
-		c.KeyPair = &KeyPairResp
-	}
 	KeyPair := pk.OptionEncoder[*user.KeyPairResp]{
-		Has: err == nil,
-		Val: &KeyPairResp,
+		Has: c.KeyPair != nil,
+		Val: c.KeyPair,
 	}
 	c.UUID, err = uuid.Parse(c.Auth.UUID)
 	PlayerUUID := pk.Option[pk.UUID, *pk.UUID]{

--- a/examples/daze/daze.go
+++ b/examples/daze/daze.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Tnze/go-mc/data/item"
 	_ "github.com/Tnze/go-mc/data/lang/zh-cn"
 	"github.com/Tnze/go-mc/level"
+	"github.com/Tnze/go-mc/yggdrasil/user"
 )
 
 var (
@@ -45,6 +46,13 @@ func main() {
 		UUID: *playerID,
 		AsTk: *accessToken,
 	}
+	// fetch key pair for message signing
+	kp, err := user.GetOrFetchKeyPair(*accessToken)
+	if err == nil {
+		client.KeyPair = &kp
+	} else {
+		log.Println("Failed to get keypair", err)
+	}
 	player = basic.NewPlayer(client, basic.DefaultSettings, basic.EventsListener{
 		GameStart:    onGameStart,
 		SystemMsg:    onSystemMsg,
@@ -66,7 +74,7 @@ func main() {
 	})
 
 	// Login
-	err := client.JoinServer(*address)
+	err = client.JoinServer(*address)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
It is user's responsibility to provide chat encryption keys (or not provide them and not sign chat).