### PR TITLE
Add option to disallow unknown fields

### DIFF
--- a/nbt/decode.go
+++ b/nbt/decode.go
@@ -370,10 +370,10 @@ func (d *Decoder) unmarshal(val reflect.Value, tagType byte) error {
 					if err != nil {
 						return fmt.Errorf("fail to decode tag %q: %w", tn, err)
 					}
-				} else {
-					if err := d.rawRead(tt); err != nil {
-						return err
-					}
+				} else if d.disallowUnknownFields {
+					return fmt.Errorf("unknown field %q", tn)
+				} else if err := d.rawRead(tt); err != nil {
+					return err
 				}
 			}
 		case reflect.Map:

--- a/nbt/decode_test.go
+++ b/nbt/decode_test.go
@@ -3,10 +3,12 @@ package nbt
 import (
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"math"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -426,5 +428,23 @@ func TestDecoder_Decode_textUnmarshaler(t *testing.T) {
 	}
 	if b != true {
 		t.Errorf("b should be true")
+	}
+}
+
+func TestDecoder_Decode_ErrorUnknownField(t *testing.T) {
+	data := []byte{
+		TagCompound, 0, 1, 'S',
+		TagByte, 0, 1, 'A', 1,
+		TagByte, 0, 1, 'B', 2,
+		TagEnd,
+	}
+	var v struct {
+		A byte `nbt:"a"`
+	}
+	d := NewDecoder(bytes.NewReader(data))
+	d.DisallowUnknownFields()
+	if _, err := d.Decode(&v); err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Errorf("should return an error unmarshalling unknown field")
+		fmt.Println(err)
 	}
 }

--- a/nbt/nbt.go
+++ b/nbt/nbt.go
@@ -33,7 +33,8 @@ type DecoderReader = interface {
 	io.Reader
 }
 type Decoder struct {
-	r DecoderReader
+	r                     DecoderReader
+	disallowUnknownFields bool
 }
 
 func NewDecoder(r io.Reader) *Decoder {
@@ -44,6 +45,12 @@ func NewDecoder(r io.Reader) *Decoder {
 		d.r = reader{r}
 	}
 	return d
+}
+
+// DisallowUnknownFields makes the decoder return an error when unmarshalling a compound
+// tag item that has a tag name not present in the destination struct.
+func (d *Decoder) DisallowUnknownFields() {
+	d.disallowUnknownFields = true
 }
 
 type reader struct {


### PR DESCRIPTION
This adds an option to disallow unknown fields for the `Decoder`, using the same interface as [DisallowUnknownFields](https://pkg.go.dev/encoding/json#Decoder.DisallowUnknownFields) from the `encoding/json` decoder. 