### PR TITLE
Fix CFB8 non-overlapping decrypt

### DIFF
--- a/net/CFB8/cfb8.go
+++ b/net/CFB8/cfb8.go
@@ -35,6 +35,9 @@ func newCFB8(c cipher.Block, iv []byte, de bool) *CFB8 {
 }
 
 func (cf *CFB8) XORKeyStream(dst, src []byte) {
+	if len(src) == 0 {
+		return
+	}
 	if len(dst) < len(src) {
 		panic("cfb8: output smaller than input")
 	}

--- a/net/CFB8/cfb8.go
+++ b/net/CFB8/cfb8.go
@@ -65,7 +65,9 @@ func (cf *CFB8) XORKeyStream(dst, src []byte) {
 			val byte
 		)
 		dst = dst[:len(src)]
-		if cf.de {
+		if cf.de && // and requires to be non-overlapping at all
+			uintptr(unsafe.Pointer(&dst[0])) <= uintptr(unsafe.Pointer(&src[len(src)-1])) &&
+			uintptr(unsafe.Pointer(&src[0])) <= uintptr(unsafe.Pointer(&dst[len(dst)-1])) {
 			for i = 0; i < len(src)-cf.blockSize; i += 1 {
 				cf.c.Encrypt(dst[i:], ciphertext[i:])
 			}


### PR DESCRIPTION
#265 introduced a new optimization to use SIMD, however, I found it does not work in some cases recently. It requires the dst and the src to be non-overlapping at all (the case in the test), but we can only ensure that "dst and src does not overlap in first block size". (see code comment)

Another frustrating thing is that in the cipher.StreamReader scenario (the case in go-mc net package), dst and src are completely overlapping, meaning they are not subject to the optimization in #265. So this PR does not actually affect the performance for go-mc net/bot package users, since they do not ever got benefited from #265, they got benefited only from #256. See https://go.dev/src/crypto/cipher/io.go#L21

I may try to optimize decryption in overlapping cases later this year (focusing on parallelism), for now I will only make small fixes.